### PR TITLE
fix: Force update PB on finish in session

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -2,7 +2,7 @@
 name = "Split Deltas"
 author = "Nixotica"
 category = "Overlay"
-version = "1.0.3"
+version = "1.0.4"
 
 [script]
 dependencies = [ "MLFeedRaceData" ]

--- a/src/SplitDelta.as
+++ b/src/SplitDelta.as
@@ -47,9 +47,17 @@ namespace SplitDelta {
         lastCpCount = currentCpCount;
         
         // Load PB times if we don't have them yet OR if the PB has been updated
-        if (player.BestTime > 0 && (pbCheckpointTimes.Length == 0 || player.BestTime != lastBestTime)) {
+        if (player.BestTime > 0 && (pbCheckpointTimes.Length == 0 || uint(player.BestTime) != lastBestTime)) {
             LoadPBTimes(player);
             lastBestTime = player.BestTime;
+        }
+        
+        // Detect finish to guarantee PB update within current session
+        auto playground = cast<CSmArenaClient>(app.CurrentPlayground);
+        if (playground is null) return;
+        auto sequence = playground.GameTerminals[0].UISequence_Current;
+        if (sequence == CGamePlaygroundUIConfig::EUISequence::Finish) {
+            Reset();
         }
     }
     


### PR DESCRIPTION
Split deltas were out of sync if a player PB'd twice in the same session. To fix this we force reset when the playground is in the finish state. Tested by driving a few PBs in a single session and verified that it updated even when quickly DNF'ing through the finish podium, not pressing Esc either. 